### PR TITLE
feat(client): persistent header and Create Deal page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,8 +2,10 @@ import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import Login from './pages/Login';
 import DealsList from './pages/DealsList';
 import DealDetail from './pages/DealDetail';
+import CreateDeal from './pages/CreateDeal';
 import { ClerkProvider, SignedIn, SignedOut } from '@clerk/clerk-react';
 import { SafeNavigationButton } from './components/SafeNavigationButton';
+import AppHeader from './components/navigation/AppHeader';
 import './App.css';
 
 const pk = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
@@ -81,10 +83,12 @@ export default function App() {
   if (!pk) {
     return (
       <div>
+        <AppHeader />
         <Routes>
           <Route path="/" element={<SetupPage />} />
           <Route path="/login" element={<SetupPage />} />
           <Route path="/deals" element={<DealsList />} />
+          <Route path="/deals/new" element={<CreateDeal />} />
           <Route path="/deals/:dealId" element={<DealDetail />} />
           <Route path="*" element={<SetupPage />} />
         </Routes>
@@ -100,10 +104,12 @@ export default function App() {
       afterSignInUrl="/deals"
       afterSignUpUrl="/deals"
     >
+      <AppHeader />
       <Routes>
         <Route path="/" element={<Navigate to="/login" replace />} />
         <Route path="/login" element={<Login />} />
         <Route path="/deals" element={<Protected><DealsList /></Protected>} />
+        <Route path="/deals/new" element={<Protected><CreateDeal /></Protected>} />
         <Route path="/deals/:dealId" element={<Protected><DealDetail /></Protected>} />
         <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>

--- a/client/src/components/navigation/AppHeader.tsx
+++ b/client/src/components/navigation/AppHeader.tsx
@@ -1,0 +1,52 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+// Avoid React hooks from Clerk here to support demo mode without provider
+
+export function AppHeader({ className }: { className?: string }) {
+  const navigate = useNavigate();
+  const hasClerk = Boolean(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
+
+  const handleBrandClick = () => {
+    if (hasClerk) {
+      navigate('/deals');
+    } else {
+      navigate('/');
+    }
+  };
+
+  const handleLogout = async () => {
+    // Use global Clerk if available, otherwise just navigate
+    const anyWindow = window as any;
+    if (anyWindow?.Clerk?.signOut) {
+      try {
+        await anyWindow.Clerk.signOut();
+      } finally {
+        navigate('/login');
+      }
+      return;
+    }
+    navigate('/');
+  };
+
+  return (
+    <header className={cn('w-full border-b bg-white', className)}>
+      <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+        <div
+          className="font-semibold text-gray-900 cursor-pointer select-none"
+          onClick={handleBrandClick}
+        >
+          Finsight
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" onClick={handleBrandClick}>Home</Button>
+          <Button onClick={() => navigate('/deals/new')}>Create Deal</Button>
+          <Button variant="outline" onClick={handleLogout}>Logout</Button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export default AppHeader;
+

--- a/client/src/pages/CreateDeal.tsx
+++ b/client/src/pages/CreateDeal.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const API_BASE_URL = 'http://localhost:3001/api';
+
+export default function CreateDeal() {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [company, setCompany] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const userId = 'user_123';
+      const response = await fetch(`${API_BASE_URL}/deals`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: company ? `${company} — ${title}` : title,
+          description: description || undefined,
+          user_id: userId,
+        }),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || 'Failed to create deal');
+      }
+
+      const created = await response.json();
+      navigate(`/deals/${created.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create deal');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    navigate('/deals');
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create New Deal</CardTitle>
+            <CardDescription>
+              Start a new deal analysis by entering the basic details. You can upload documents on the next page.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-5" onSubmit={handleSubmit}>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Company Name (optional)</label>
+                <input
+                  type="text"
+                  className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="e.g., TechCorp Inc."
+                  value={company}
+                  onChange={(e) => setCompany(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Deal Title</label>
+                <input
+                  type="text"
+                  className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="e.g., Acquisition of AI division"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  disabled={submitting}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Description (optional)</label>
+                <textarea
+                  className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  rows={4}
+                  placeholder="Brief summary of the deal context and goals"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+
+              {error && (
+                <div className="bg-red-50 border border-red-200 rounded-md p-3">
+                  <p className="text-red-800 text-sm">{error}</p>
+                </div>
+              )}
+
+              <div className="flex items-center gap-3">
+                <Button type="submit" disabled={submitting} className="bg-blue-600 hover:bg-blue-700">
+                  {submitting ? 'Creating…' : 'Create Deal'}
+                </Button>
+                <Button type="button" variant="ghost" onClick={handleCancel} disabled={submitting}>
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/pages/DealsList.tsx
+++ b/client/src/pages/DealsList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
+import { SafeNavigationButton } from '@/components/SafeNavigationButton';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 // Mock data for deals
@@ -42,11 +43,7 @@ export default function DealsList() {
     navigate(`/deals/${dealId}`);
   };
 
-  const handleBackClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    navigate('/');
-  };
+  // Back to Home uses SafeNavigationButton for robust navigation
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -73,12 +70,12 @@ export default function DealsList() {
               Manage and track your financial deals with intelligent insights
             </p>
           </div>
-          <div 
-            onClick={handleBackClick}
-            className="bg-gray-600 text-white py-2 px-4 rounded-md hover:bg-gray-700 transition-colors cursor-pointer text-center"
+          <SafeNavigationButton 
+            to="/"
+            className="bg-gray-600 text-white py-2 px-4"
           >
             Back to Home
-          </div>
+          </SafeNavigationButton>
         </div>
 
         <div className="grid gap-6">

--- a/server/src/config/supabase.ts
+++ b/server/src/config/supabase.ts
@@ -1,4 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Ensure environment variables are loaded before reading them
+// ESM imports are evaluated before module body in other files, so we load here as well
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;


### PR DESCRIPTION
Add AppHeader displayed across all routes with Home, Create Deal, and Logout controls.

Create Deal page (/deals/new):

- Simple form with Company (optional), Title (required), Description (optional)

- Submits to POST /api/deals with { title, description?, user_id } and navigates to /deals/:id on success

Routing:

- Added /deals/new in both demo mode and Clerk-protected mode

- Header included in both modes

Testing notes:

- Run npm run dev, visit http://localhost:5173/

- Header appears on all pages; Home, Create Deal, Logout work

Files changed:

- client/src/components/navigation/AppHeader.tsx (new)

- client/src/pages/CreateDeal.tsx (new)

- client/src/App.tsx

- client/src/pages/DealsList.tsx

- server/src/config/supabase.ts