### PR TITLE
Fix H2H revenue, profit margin, and growth rate display

### DIFF
--- a/client/src/pages/HeadToHead.tsx
+++ b/client/src/pages/HeadToHead.tsx
@@ -114,12 +114,21 @@ export default function HeadToHead() {
           }
 
           return {
-          deal: { ...deal, metrics: realMetrics, health_score: realHealthScore },
-          score: Math.round(score),
-          rank: 0,
-          strengths,
-          weaknesses
-        };
+            deal: { 
+              ...deal, 
+              metrics: {
+                ...realMetrics,
+                revenue: realRevenue,
+                profit_margin: profitMargin,
+                growth_rate: growthRate
+              }, 
+              health_score: realHealthScore 
+            },
+            score: Math.round(score),
+            rank: 0,
+            strengths,
+            weaknesses
+          };
       });
 
       // Sort by score (highest first) and assign ranks


### PR DESCRIPTION
Changes
✅ Real Data Integration: H2H uses actual financial data from CSV files
✅ Fixed Display Issues: Revenue, profit margin, and growth rate now show real values
✅ Unique Company Profiles: 3 distinct datasets (winner, runner-up, third-place)
✅ Complete CSV Sets: Each profile includes financials, PnL, BS, and CF data
✅ Backend Endpoints: /api/analyze/real-analysis-data and /api/analyze/multi-company-data
✅ Frontend Updates: Modified DealDetail.tsx and HeadToHead.tsx to use real data
✅ AI Analysis: Fixed authentication and model issues
